### PR TITLE
feat(core): Implement target language detection for pasted code (#3)

### DIFF
--- a/codetranslator/src/extension.ts
+++ b/codetranslator/src/extension.ts
@@ -98,7 +98,6 @@ export function activate(context: vscode.ExtensionContext) {
 				updateTargetLanguage();
 				
 				// Retrieve the updated target language
-				// Retrieve the updated target language
 				
 				// Log detection results to output panel
 				outputChannel.appendLine(`--- Paste Detection ---`);

--- a/codetranslator/src/extension.ts
+++ b/codetranslator/src/extension.ts
@@ -3,6 +3,12 @@
 import * as vscode from 'vscode';
 import { detectLanguage, isProbablyPaste } from './languageDetector';
 
+// Global variable to store the target language (current file's language)
+let targetLang: string | null = null;
+
+// Create output channel for logging
+let outputChannel: vscode.OutputChannel;
+
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
@@ -10,6 +16,48 @@ export function activate(context: vscode.ExtensionContext) {
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated
 	console.log('Congratulations, your extension "codetranslator" is now active!');
+
+	// Create output channel for logging CodeTranslator activity
+	outputChannel = vscode.window.createOutputChannel("CodeTranslator");
+	outputChannel.appendLine('CodeTranslator extension activated');
+
+	/**
+	 * Function to detect and update the current file language (target language)
+	 * This determines what language the pasted code should be translated into
+	 */
+	function updateTargetLanguage(): void {
+		// Check if there's an active text editor
+		const activeEditor = vscode.window.activeTextEditor;
+		
+		if (activeEditor) {
+			// Get the language ID of the current document
+			const currentLanguageId = activeEditor.document.languageId;
+			
+			// Update the target language
+			targetLang = currentLanguageId;
+			
+			// Log to output panel
+			outputChannel.appendLine(`Target language detected: ${targetLang}`);
+			outputChannel.appendLine(`File: ${activeEditor.document.fileName}`);
+			
+			// Log to console for debugging
+			console.log(`CodeTranslator: Target language set to '${targetLang}'`);
+			console.log(`CodeTranslator: Active file is '${activeEditor.document.fileName}'`);
+		} else {
+			// No active editor, clear target language
+			targetLang = null;
+			outputChannel.appendLine('No active editor - target language cleared');
+			console.log('CodeTranslator: No active editor, target language cleared');
+		}
+	}
+
+	// Detect target language on activation
+	updateTargetLanguage();
+
+	// Listen for active editor changes to update target language
+	const onDidChangeActiveTextEditor = vscode.window.onDidChangeActiveTextEditor(() => {
+		updateTargetLanguage();
+	});
 
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with registerCommand
@@ -45,25 +93,41 @@ export function activate(context: vscode.ExtensionContext) {
 			const detectedLanguage = detectLanguage(pastedText);
 			
 			if (detectedLanguage) {
-				// Get the current file's language for comparison
-				const currentLanguage = event.document.languageId;
+				// Get the current file's language (target language) with safety check
+				const activeEditor = vscode.window.activeTextEditor;
+				const currentLanguage = activeEditor ? activeEditor.document.languageId : null;
+				
+				// Update target language if we have an active editor
+				if (currentLanguage) {
+					targetLang = currentLanguage;
+				}
+				
+				// Log detection results to output panel
+				outputChannel.appendLine(`--- Paste Detection ---`);
+				outputChannel.appendLine(`Detected source language: ${detectedLanguage}`);
+				outputChannel.appendLine(`Target language: ${targetLang || 'unknown'}`);
 				
 				// Show detection result to user
-				if (detectedLanguage === currentLanguage) {
+				if (detectedLanguage === targetLang) {
 					vscode.window.showInformationMessage(
 						`✅ Detected Language: ${detectedLanguage} (matches current file)`
 					);
+					outputChannel.appendLine(`Status: Source and target languages match - no translation needed`);
 				} else {
 					vscode.window.showInformationMessage(
-						`🔍 Detected Language: ${detectedLanguage} (current file: ${currentLanguage})`
+						`🔍 Detected Language: ${detectedLanguage} (target: ${targetLang || 'unknown'})`
 					);
+					outputChannel.appendLine(`Status: Translation will be needed from ${detectedLanguage} to ${targetLang || 'unknown'}`);
 				}
 				
 				// Log for debugging purposes
 				console.log(`CodeTranslator: Detected language '${detectedLanguage}' for pasted code`);
-				console.log(`CodeTranslator: Current file language is '${currentLanguage}'`);
+				console.log(`CodeTranslator: Target language is '${targetLang}'`);
 			} else {
 				// Language couldn't be detected with confidence
+				outputChannel.appendLine(`--- Paste Detection ---`);
+				outputChannel.appendLine(`Could not detect language of pasted code`);
+				outputChannel.appendLine(`Target language: ${targetLang || 'unknown'}`);
 				console.log('CodeTranslator: Could not detect language of pasted code');
 			}
 		} catch (error) {
@@ -72,7 +136,12 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	// Add all disposables to the context
-	context.subscriptions.push(onDidChangeTextDocument);
+	context.subscriptions.push(
+		disposable,
+		onDidChangeTextDocument,
+		onDidChangeActiveTextEditor,
+		outputChannel
+	);
 }
 
 // This method is called when your extension is deactivated

--- a/codetranslator/src/extension.ts
+++ b/codetranslator/src/extension.ts
@@ -41,13 +41,13 @@ export function activate(context: vscode.ExtensionContext) {
 			outputChannel.appendLine(`File: ${activeEditor.document.fileName}`);
 			
 			// Log to console for debugging
-			console.log(`CodeTranslator: Target language set to '${targetLang}'`);
-			console.log(`CodeTranslator: Active file is '${activeEditor.document.fileName}'`);
+			// Removed redundant console.log call for target language
+			// Removed redundant console.log call for active file
 		} else {
 			// No active editor, clear target language
 			targetLang = null;
 			outputChannel.appendLine('No active editor - target language cleared');
-			console.log('CodeTranslator: No active editor, target language cleared');
+			// Removed redundant console.log call for no active editor
 		}
 	}
 

--- a/codetranslator/src/extension.ts
+++ b/codetranslator/src/extension.ts
@@ -98,7 +98,7 @@ export function activate(context: vscode.ExtensionContext) {
 				updateTargetLanguage();
 				
 				// Retrieve the updated target language
-				const currentLanguage = targetLang;
+				// Retrieve the updated target language
 				
 				// Log detection results to output panel
 				outputChannel.appendLine(`--- Paste Detection ---`);

--- a/codetranslator/src/extension.ts
+++ b/codetranslator/src/extension.ts
@@ -94,13 +94,11 @@ export function activate(context: vscode.ExtensionContext) {
 			
 			if (detectedLanguage) {
 				// Get the current file's language (target language) with safety check
-				const activeEditor = vscode.window.activeTextEditor;
-				const currentLanguage = activeEditor ? activeEditor.document.languageId : null;
+				// Update target language using centralized logic
+				updateTargetLanguage();
 				
-				// Update target language if we have an active editor
-				if (currentLanguage) {
-					targetLang = currentLanguage;
-				}
+				// Retrieve the updated target language
+				const currentLanguage = targetLang;
 				
 				// Log detection results to output panel
 				outputChannel.appendLine(`--- Paste Detection ---`);


### PR DESCRIPTION
This pull request implements the core functionality for detecting the programming language of the currently active file, which will serve as the **target language** for future translations. It lays the essential groundwork for the extension's primary feature.

### Key Changes
- **Target Language State:** A new `targetLang` variable now holds the language ID of the active file.
- **Real-time Updates:** The target language is automatically updated on extension startup and whenever the user switches between open files, thanks to the `onDidChangeActiveTextEditor` listener.
- **Dedicated Output Channel:** A "CodeTranslator" output channel has been added for clear, user-facing logs, making it easy to debug and see the extension's activity.
- **Integrated Logic:** The new target language detection is now integrated into the paste handler (`onDidChangeTextDocument`), allowing for a direct comparison between the detected source language and the target language.
- **Robustness:** Added safety checks to ensure the extension doesn't crash if no editor is active (`window.activeTextEditor` is `undefined`).
- **Improved User Feedback:** The informational pop-up now clearly shows both the detected source language and the target language.

This resolves all tasks outlined in the original issue and prepares the extension for the next step: performing the actual translation.

Resolves #3